### PR TITLE
feat: directory namespaces support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Add it to `vite.config.js`
 
 ```ts
 // vite.config.js
-import ViteComponents from 'vite-plugin-components';
+import ViteComponents from 'vite-plugin-components'
 
 export default {
-	plugins: [
+  plugins: [
     ViteComponents()
   ],
 };
@@ -47,15 +47,15 @@ Basically, it will automatically turn this
 
 ```vue
 <template>
-	<div>
-		<HelloWorld msg="Hello Vue 3.0 + Vite" />
-	</div>
+  <div>
+    <HelloWorld msg="Hello Vue 3.0 + Vite" />
+  </div>
 </template>
 
 <script>
-	export default {
-		name: 'App',
-	};
+  export default {
+    name: 'App',
+  }
 </script>
 ```
 
@@ -63,20 +63,20 @@ into this
 
 ```vue
 <template>
-	<div>
-		<HelloWorld msg="Hello Vue 3.0 + Vite" />
-	</div>
+  <div>
+    <HelloWorld msg="Hello Vue 3.0 + Vite" />
+  </div>
 </template>
 
 <script>
-	import HelloWorld from './src/components/HelloWorld.vue';
+  import HelloWorld from './src/components/HelloWorld.vue'
 
-	export default {
-		name: 'App',
-		components: {
-			HelloWorld,
-		},
-	};
+  export default {
+    name: 'App',
+    components: {
+      HelloWorld,
+    },
+  };
 </script>
 ```
 
@@ -86,22 +86,25 @@ The following show the default values of the configuration
 
 ```ts
 ViteComponents({
-	// relative paths to the directory to search for components.
-  dirs: ['src/components']
+  // relative paths to the directory to search for components.
+  dirs: ['src/components'],
+
+  // valid file extensions for components.
+  extensions: ['vue'],
+  // search for subdirectories
+  deep: true,
+
+  // allow folder as component name prefix
+  folderNamespace: false,
   // Directory names that are ignored as Component names.
   // Only works if Foldernames are allowed
   globalNamespaces: ['global', 'partials'],
-	// valid file extensions for components.
-	extensions: ['vue'],
-	// search for subdirectories
-	deep: true,
-	// allow folder as component names
-	folderNamespace: false,
-	// vite config
-	// currently, vite does not provide an API for plugins to get the config https://github.com/vitejs/vite/issues/738
-	// you will need to pass `alias` and `root` if you set them in vite config
-	alias: {},
-	root: process.cwd(),
+  
+  // vite config
+  // currently, vite does not provide an API for plugins to get the config https://github.com/vitejs/vite/issues/738
+  // you will need to pass `alias` and `root` if you set them in vite config
+  alias: {},
+  root: process.cwd(),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ ViteComponents({
   directoryAsNamespace: false,
   // Subdirectory paths for ignoring namespace prefixes
   // works when `directoryAsNamespace: true`
-  globalNamespaces: ['global', 'partials'],
+  globalNamespaces: [],
   
   // vite config
   // currently, vite does not provide an API for plugins to get the config https://github.com/vitejs/vite/issues/738

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ViteComponents({
   // you will need to pass `alias` and `root` if you set them in vite config
   alias: {},
   root: process.cwd(),
-});
+})
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Basically, it will automatically turn this
 </template>
 
 <script>
-  export default {
-    name: 'App',
-  }
+export default {
+  name: 'App'
+}
 </script>
 ```
 
@@ -69,14 +69,14 @@ into this
 </template>
 
 <script>
-  import HelloWorld from './src/components/HelloWorld.vue'
+import HelloWorld from './src/components/HelloWorld.vue'
 
-  export default {
-    name: 'App',
-    components: {
-      HelloWorld,
-    },
-  };
+export default {
+  name: 'App',
+  components: {
+    HelloWorld
+  }
+}
 </script>
 ```
 
@@ -94,10 +94,10 @@ ViteComponents({
   // search for subdirectories
   deep: true,
 
-  // allow folder as component name prefix
-  folderNamespace: false,
-  // Directory names that are ignored as Component names.
-  // Only works if Foldernames are allowed
+  // Allow subdirectories as namespace prefix for components.
+  directoryAsNamespace: false,
+  // Subdirectory paths for ignoring namespace prefixes
+  // works when `directoryAsNamespace: true`
   globalNamespaces: ['global', 'partials'],
   
   // vite config

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Add it to `vite.config.js`
 import ViteComponents from 'vite-plugin-components';
 
 export default {
-	plugins: [ViteComponents()],
+	plugins: [
+    ViteComponents()
+  ],
 };
 ```
 
@@ -85,13 +87,16 @@ The following show the default values of the configuration
 ```ts
 ViteComponents({
 	// relative paths to the directory to search for components.
-	include_dirs: ['src/components'],
+  dirs: ['src/components']
+  // Directory names that are ignored as Component names.
+  // Only works if Foldernames are allowed
+  globalNamespaces: ['global', 'partials'],
 	// valid file extensions for components.
 	extensions: ['vue'],
 	// search for subdirectories
 	deep: true,
 	// allow folder as component names
-	allowFolderNames: true,
+	folderNamespace: false,
 	// vite config
 	// currently, vite does not provide an API for plugins to get the config https://github.com/vitejs/vite/issues/738
 	// you will need to pass `alias` and `root` if you set them in vite config

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
   </a>
 </p>
 
-
 <br>
 
 ## Usage
@@ -31,16 +30,14 @@ Add it to `vite.config.js`
 
 ```ts
 // vite.config.js
-import ViteComponents from 'vite-plugin-components'
+import ViteComponents from 'vite-plugin-components';
 
 export default {
-  plugins: [
-    ViteComponents()
-  ]
-}
+	plugins: [ViteComponents()],
+};
 ```
 
-That's all. 
+That's all.
 
 Use components in templates as you would usually do but NO `import` and `component registration` required anymore! It will import components on demand, code splitting is also possible.
 
@@ -48,15 +45,15 @@ Basically, it will automatically turn this
 
 ```vue
 <template>
-  <div>
-    <HelloWorld msg="Hello Vue 3.0 + Vite" />
-  </div>
+	<div>
+		<HelloWorld msg="Hello Vue 3.0 + Vite" />
+	</div>
 </template>
 
 <script>
-export default {
-  name: 'App'
-}
+	export default {
+		name: 'App',
+	};
 </script>
 ```
 
@@ -64,20 +61,20 @@ into this
 
 ```vue
 <template>
-  <div>
-    <HelloWorld msg="Hello Vue 3.0 + Vite" />
-  </div>
+	<div>
+		<HelloWorld msg="Hello Vue 3.0 + Vite" />
+	</div>
 </template>
 
 <script>
-import HelloWorld from './src/components/HelloWorld.vue'
+	import HelloWorld from './src/components/HelloWorld.vue';
 
-export default {
-  name: 'App',
-  components: {
-    HelloWorld
-  }
-}
+	export default {
+		name: 'App',
+		components: {
+			HelloWorld,
+		},
+	};
 </script>
 ```
 
@@ -87,19 +84,20 @@ The following show the default values of the configuration
 
 ```ts
 ViteComponents({
-  // relative paths to the directory to search for components.
-  dirs: ['src/components'],
-  // valid file extensions for components.
-  extensions: ['vue'],
-  // search for subdirectories
-  deep: true,
-
-  // vite config
-  // currently, vite does not provide an API for plugins to get the config https://github.com/vitejs/vite/issues/738
-  // you will need to pass `alias` and `root` if you set them in vite config
-  alias: {},
-  root: process.cwd(),
-})
+	// relative paths to the directory to search for components.
+	include_dirs: ['src/components'],
+	// valid file extensions for components.
+	extensions: ['vue'],
+	// search for subdirectories
+	deep: true,
+	// allow folder as component names
+	allowFolderNames: true,
+	// vite config
+	// currently, vite does not provide an API for plugins to get the config https://github.com/vitejs/vite/issues/738
+	// you will need to pass `alias` and `root` if you set them in vite config
+	alias: {},
+	root: process.cwd(),
+});
 ```
 
 ## Example

--- a/src/context.ts
+++ b/src/context.ts
@@ -78,7 +78,6 @@ export class Context {
       .from(this._componentPaths)
       .forEach((path) => {
         const name = normalize(getNameFromFilePath(path, this.options.include_dirs, this.options.allowFolderNames, this.options.namespaces))
-        console.log(name);
         if (this._componentNameMap[name]) {
           console.warn(`[vite-plugin-components] component "${name}"(${path}) has naming conflicts with other components, ignored.`)
           return

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,14 +19,18 @@ export class Context {
   constructor(
     public readonly options: Options,
   ) {
-    const { extensions, dirs, deep } = options
+    const { 
+        extensions, 
+        include_dirs, 
+        deep,
+    } = options
     const exts = toArray(extensions)
 
     if (!exts.length)
       throw new Error('[vite-plugin-components] extensions are required to search for components')
 
     const extsGlob = exts.length === 1 ? exts[0] : `{${exts.join(',')}}`
-    this.globs = toArray(dirs).map(i =>
+    this.globs = toArray(include_dirs).map(i =>
       deep
         ? `${i}/**/*.${extsGlob}`
         : `${i}/*.${extsGlob}`,
@@ -73,7 +77,8 @@ export class Context {
     Array
       .from(this._componentPaths)
       .forEach((path) => {
-        const name = normalize(getNameFromFilePath(path))
+        const name = normalize(getNameFromFilePath(path, this.options.include_dirs, this.options.allowFolderNames, this.options.namespaces))
+        console.log(name);
         if (this._componentNameMap[name]) {
           console.warn(`[vite-plugin-components] component "${name}"(${path}) has naming conflicts with other components, ignored.`)
           return

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,10 +19,10 @@ export class Context {
   constructor(
     public readonly options: Options,
   ) {
-    const { 
-        extensions, 
-        include_dirs, 
-        deep,
+    const {
+      extensions,
+      dirs,
+      deep,
     } = options
     const exts = toArray(extensions)
 
@@ -30,7 +30,7 @@ export class Context {
       throw new Error('[vite-plugin-components] extensions are required to search for components')
 
     const extsGlob = exts.length === 1 ? exts[0] : `{${exts.join(',')}}`
-    this.globs = toArray(include_dirs).map(i =>
+    this.globs = toArray(dirs).map(i =>
       deep
         ? `${i}/**/*.${extsGlob}`
         : `${i}/*.${extsGlob}`,

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,17 +19,14 @@ export class Context {
   constructor(
     public readonly options: Options,
   ) {
-    const {
-      extensions,
-      dirs,
-      deep,
-    } = options
+    const { extensions, dirs, deep } = options
     const exts = toArray(extensions)
 
     if (!exts.length)
       throw new Error('[vite-plugin-components] extensions are required to search for components')
 
     const extsGlob = exts.length === 1 ? exts[0] : `{${exts.join(',')}}`
+
     this.globs = toArray(dirs).map(i =>
       deep
         ? `${i}/**/*.${extsGlob}`
@@ -77,7 +74,7 @@ export class Context {
     Array
       .from(this._componentPaths)
       .forEach((path) => {
-        const name = normalize(getNameFromFilePath(path, this.options.include_dirs, this.options.allowFolderNames, this.options.namespaces))
+        const name = normalize(getNameFromFilePath(path, this.options))
         if (this._componentNameMap[name]) {
           console.warn(`[vite-plugin-components] component "${name}"(${path}) has naming conflicts with other components, ignored.`)
           return

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const defaultOptions: Options = {
   ],
   extensions: 'vue',
   deep: true,
-  allowFolderNames: true,
+  allowFolderNames: false,
   alias: {},
   root: process.cwd(),
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,13 @@ import { VueTemplateTransformer } from './transforms/vueTemplate'
 import { Context } from './context'
 
 const defaultOptions: Options = {
-  include_dirs: 'src/components',
-  namespaces: [
-    'global',
-    'partials'
-  ],
+  dirs: 'src/components',
   extensions: 'vue',
   deep: true,
-  allowFolderNames: false,
+
+  directoryAsNamespace: false,
+  globalNamespaces: [],
+
   alias: {},
   root: process.cwd(),
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,14 @@ import { VueTemplateTransformer } from './transforms/vueTemplate'
 import { Context } from './context'
 
 const defaultOptions: Options = {
-  dirs: 'src/components',
+  include_dirs: 'src/components',
+  namespaces: [
+    'global',
+    'partials'
+  ],
   extensions: 'vue',
   deep: true,
+  allowFolderNames: true,
   alias: {},
   root: process.cwd(),
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,14 +6,14 @@ export interface Options {
    * Relative paths to the directory to search for components.
    * @default 'src/components'
    */
-  include_dirs: string | string[]
+  dirs: string | string[]
 
   /**
    * Directory names that are ignored as Component names.
    * Only works if Foldernames are allowed
    * @default "['global', 'partials']"
-   */ 
-  namespaces: string[]
+   */
+  globalNamespaces: string[]
 
   /**
    * Valid file extensions for components.
@@ -32,14 +32,14 @@ export interface Options {
    * @default false
    */
 
-  allowFolderNames: boolean
+  folderNamespace: boolean
 
   /**
    * Path alias, same as what you passed to vite root config
    * @default {}
    */
   alias: Record<string, string>
-  
+
   /**
    * Root path of Vite project.
    * @default 'process.cwd()'

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,13 +9,6 @@ export interface Options {
   dirs: string | string[]
 
   /**
-   * Directory names that are ignored as Component names.
-   * Only works if Foldernames are allowed
-   * @default "['global', 'partials']"
-   */
-  globalNamespaces: string[]
-
-  /**
    * Valid file extensions for components.
    * @default ['vue']
    */
@@ -28,10 +21,17 @@ export interface Options {
   deep: boolean
 
   /**
-   * Allow directories as Names for components
+   * Allow subdirectories as namespace prefix for components
    * @default false
    */
   directoryAsNamespace: boolean
+
+  /**
+   * Subdirectory paths for ignoring namespace prefixes
+   * works when `directoryAsNamespace: true`
+   * @default "[]"
+   */
+  globalNamespaces: string[]
 
   /**
    * Path alias, same as what you passed to vite root config

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,7 @@ export interface Options {
    * Allow directories as Names for components
    * @default false
    */
-
-  folderNamespace: boolean
+  directoryAsNamespace: boolean
 
   /**
    * Path alias, same as what you passed to vite root config

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,22 +6,40 @@ export interface Options {
    * Relative paths to the directory to search for components.
    * @default 'src/components'
    */
-  dirs: string | string[]
+  include_dirs: string | string[]
+
+  /**
+   * Directory names that are ignored as Component names.
+   * Only works if Foldernames are allowed
+   * @default "['global', 'partials']"
+   */ 
+  namespaces: string[]
+
   /**
    * Valid file extensions for components.
    * @default ['vue']
    */
   extensions: string | string[]
+
   /**
    * Search for subdirectories
    * @default true
    */
   deep: boolean
+
+  /**
+   * Allow directories as Names for components
+   * @default false
+   */
+
+  allowFolderNames: boolean
+
   /**
    * Path alias, same as what you passed to vite root config
    * @default {}
    */
   alias: Record<string, string>
+  
   /**
    * Root path of Vite project.
    * @default 'process.cwd()'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,22 @@ export function toArray<T>(arr: T | T[]): T[] {
   return [arr]
 }
 
+export function split(str: string, sep: string) {
+    return str == '' ? [] : str.split(sep);
+}
+
+export function join(arr: string[], sep: string) {
+	return arr == null ? '' : Array.prototype.join.call(arr, sep);
+}
+
+export function isEmpty(value: any) {
+    if (!value || value === null || value === undefined || (Array.isArray(value) && Object.keys(value).length <= 0)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 export function matchGlobs(filepath: string, globs: string[]) {
   for (const glob of globs) {
     if (minimatch(filepath, glob))
@@ -28,16 +44,50 @@ export function matchGlobs(filepath: string, globs: string[]) {
   return false
 }
 
-export function getNameFromFilePath(filePath: string): string {
-  const parsedFilePath = path.parse(filePath)
-  if (parsedFilePath.name === 'index') {
-    const filePathSegments = filePath.split(path.sep)
-    const parentDirName = filePathSegments[filePathSegments.length - 2]
-    if (parentDirName)
-      return parentDirName
-  }
-  return parsedFilePath.name
+export function getNameFromFilePath(filePath: string, includedFrom: string | string[], allowFolderNames: boolean, namespaces: string[]): string {
+    const parsedFilePath = path.parse(filePath);
+
+    let strippedPath = '';
+
+    // remove include directories from filepath
+
+    if(Array.isArray(includedFrom)) {
+        includedFrom.forEach((inc: string) => {
+            if(parsedFilePath.dir.includes(inc)) {
+                strippedPath = parsedFilePath.dir.replace(inc, '');
+            }
+        });
+    } else {
+        strippedPath = parsedFilePath.dir.replace(includedFrom, '');  
+    }
+
+    let folders = split(strippedPath.slice(1), "/");
+    let filename = parsedFilePath.name;
+
+    // set parent directory as filename if it is index 
+    if(filename === 'index') {
+        filename = `${folders.slice(-1)[0]}`;
+        return filename;
+    }
+
+    if (allowFolderNames) {
+        // remove namesspaces from folder names
+        if (namespaces.some((name: string) => folders.includes(name))) {
+            folders = folders.filter((f) => !namespaces.includes(f));
+        }
+
+        if(!isEmpty(folders)) {
+            // add folders to filename
+            filename = `${join(folders, '')}${filename}`;
+        }
+        
+        return filename;
+    }
+
+    return filename
 }
+
+
 
 export function resolveAlias(filepath: string, alias: Record<string, string>) {
   let result = filepath

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 // @ts-ignore
 import minimatch from 'minimatch'
+import { Options } from './types';
 
 export function normalize(str: string) {
   return capitalize(camelize(str))
@@ -21,11 +22,11 @@ export function toArray<T>(arr: T | T[]): T[] {
 }
 
 export function split(str: string, sep: string) {
-    return str == '' ? [] : str.split(sep)
+  return str == '' ? [] : str.split(sep)
 }
 
 export function join(arr: string[], sep: string) {
-	return arr == null ? '' : Array.prototype.join.call(arr, sep)
+  return arr == null ? '' : Array.prototype.join.call(arr, sep)
 }
 
 export function isEmpty(value: any) {
@@ -44,43 +45,45 @@ export function matchGlobs(filepath: string, globs: string[]) {
   return false
 }
 
-export function getNameFromFilePath(filePath: string, includedFrom: string | string[], allowFolderNames: boolean, namespaces: string[]): string {
+export function getNameFromFilePath(filePath: string, options: Options): string {
+  const { dirs, folderNamespace, globalNamespaces } = options;
+
   const parsedFilePath = path.parse(filePath)
 
   let strippedPath = ''
 
   // remove include directories from filepath
 
-  if(Array.isArray(includedFrom)) {
-    includedFrom.forEach((inc: string) => {
-      if(parsedFilePath.dir.includes(inc)) {
+  if (Array.isArray(dirs)) {
+    dirs.forEach((inc: string) => {
+      if (parsedFilePath.dir.includes(inc)) {
         strippedPath = parsedFilePath.dir.replace(inc, '')
       }
     })
   } else {
-    strippedPath = parsedFilePath.dir.replace(includedFrom, '')
+    strippedPath = parsedFilePath.dir.replace(dirs, '')
   }
 
   let folders = split(strippedPath.slice(1), "/")
   let filename = parsedFilePath.name
 
   // set parent directory as filename if it is index 
-  if(filename === 'index') {
+  if (filename === 'index') {
     filename = `${folders.slice(-1)[0]}`
     return filename
   }
 
-  if (allowFolderNames) {
+  if (folderNamespace) {
     // remove namesspaces from folder names
-    if (namespaces.some((name: string) => folders.includes(name))) {
-      folders = folders.filter((f) => !namespaces.includes(f))
+    if (globalNamespaces.some((name: string) => folders.includes(name))) {
+      folders = folders.filter((f) => !globalNamespaces.includes(f))
     }
 
-    if(!isEmpty(folders)) {
+    if (!isEmpty(folders)) {
       // add folders to filename
       filename = `${join(folders, '')}${filename}`
     }
-    
+
     return filename;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,19 +21,19 @@ export function toArray<T>(arr: T | T[]): T[] {
 }
 
 export function split(str: string, sep: string) {
-    return str == '' ? [] : str.split(sep);
+    return str == '' ? [] : str.split(sep)
 }
 
 export function join(arr: string[], sep: string) {
-	return arr == null ? '' : Array.prototype.join.call(arr, sep);
+	return arr == null ? '' : Array.prototype.join.call(arr, sep)
 }
 
 export function isEmpty(value: any) {
-    if (!value || value === null || value === undefined || (Array.isArray(value) && Object.keys(value).length <= 0)) {
-        return true;
-    } else {
-        return false;
-    }
+  if (!value || value === null || value === undefined || (Array.isArray(value) && Object.keys(value).length <= 0)) {
+    return true
+  } else {
+    return false
+  }
 }
 
 export function matchGlobs(filepath: string, globs: string[]) {
@@ -45,46 +45,46 @@ export function matchGlobs(filepath: string, globs: string[]) {
 }
 
 export function getNameFromFilePath(filePath: string, includedFrom: string | string[], allowFolderNames: boolean, namespaces: string[]): string {
-    const parsedFilePath = path.parse(filePath);
+  const parsedFilePath = path.parse(filePath)
 
-    let strippedPath = '';
+  let strippedPath = ''
 
-    // remove include directories from filepath
+  // remove include directories from filepath
 
-    if(Array.isArray(includedFrom)) {
-        includedFrom.forEach((inc: string) => {
-            if(parsedFilePath.dir.includes(inc)) {
-                strippedPath = parsedFilePath.dir.replace(inc, '');
-            }
-        });
-    } else {
-        strippedPath = parsedFilePath.dir.replace(includedFrom, '');  
-    }
+  if(Array.isArray(includedFrom)) {
+    includedFrom.forEach((inc: string) => {
+      if(parsedFilePath.dir.includes(inc)) {
+        strippedPath = parsedFilePath.dir.replace(inc, '')
+      }
+    })
+  } else {
+    strippedPath = parsedFilePath.dir.replace(includedFrom, '')
+  }
 
-    let folders = split(strippedPath.slice(1), "/");
-    let filename = parsedFilePath.name;
+  let folders = split(strippedPath.slice(1), "/")
+  let filename = parsedFilePath.name
 
-    // set parent directory as filename if it is index 
-    if(filename === 'index') {
-        filename = `${folders.slice(-1)[0]}`;
-        return filename;
-    }
-
-    if (allowFolderNames) {
-        // remove namesspaces from folder names
-        if (namespaces.some((name: string) => folders.includes(name))) {
-            folders = folders.filter((f) => !namespaces.includes(f));
-        }
-
-        if(!isEmpty(folders)) {
-            // add folders to filename
-            filename = `${join(folders, '')}${filename}`;
-        }
-        
-        return filename;
-    }
-
+  // set parent directory as filename if it is index 
+  if(filename === 'index') {
+    filename = `${folders.slice(-1)[0]}`
     return filename
+  }
+
+  if (allowFolderNames) {
+    // remove namesspaces from folder names
+    if (namespaces.some((name: string) => folders.includes(name))) {
+      folders = folders.filter((f) => !namespaces.includes(f))
+    }
+
+    if(!isEmpty(folders)) {
+      // add folders to filename
+      filename = `${join(folders, '')}${filename}`
+    }
+    
+    return filename;
+  }
+
+  return filename
 }
 
 

--- a/test/fixture/src/App.vue
+++ b/test/fixture/src/App.vue
@@ -1,18 +1,23 @@
 <template>
-  <ComponentA msg="a" />
-  <component-b msg="b" />
-  <ComponentC msg="c" />
-  <recursive :data="tree" />
+    <ComponentA msg="a" />
+    <component-b msg="b" />
+    <ComponentC msg="c" />
+    <recursive :data="tree" />
+    <!-- If you allow Folder Names uncomment these Components -->
+    <!-- 
+        <avatar />
+        <ui-Button /> 
+    -->
 </template>
 
 <script setup lang='ts'>
-import { ref } from 'vue'
+import { ref } from "vue";
 
 export const tree = ref({
-  label: 'Top Level',
-  children: [
-    { label: 'First Level' },
-    { label: 'First Level', children: [{ label: 'Second Level' }] },
-  ],
-})
+    label: "Top Level",
+    children: [
+        { label: "First Level" },
+        { label: "First Level", children: [{ label: "Second Level" }] },
+    ],
+});
 </script>

--- a/test/fixture/src/App.vue
+++ b/test/fixture/src/App.vue
@@ -1,22 +1,22 @@
 <template>
-    <ComponentA msg="a" />
-    <component-b msg="b" />
-    <ComponentC msg="c" />
-    <recursive :data="tree" />
-    <Book />
-    <!-- If you allow Folder Names uncomment these Components -->
-    <Avatar />
-    <Uibutton />
+  <ComponentA msg="a" />
+  <component-b msg="b" />
+  <ComponentC msg="c" />
+  <recursive :data="tree" />
+  <Book />
+  <!-- If you allow Folder Names uncomment these Components -->
+  <Avatar />
+  <Uibutton />
 </template>
 
 <script setup lang='ts'>
-import { ref } from "vue";
+import { ref } from "vue"
 
 export const tree = ref({
-    label: "Top Level",
-    children: [
-        { label: "First Level" },
-        { label: "First Level", children: [{ label: "Second Level" }] },
-    ],
-});
+  label: "Top Level",
+  children: [
+      { label: "First Level" },
+      { label: "First Level", children: [{ label: "Second Level" }] },
+  ],
+})
 </script>

--- a/test/fixture/src/App.vue
+++ b/test/fixture/src/App.vue
@@ -10,13 +10,13 @@
 </template>
 
 <script setup lang='ts'>
-import { ref } from "vue"
+import { ref } from 'vue';
 
 export const tree = ref({
-  label: "Top Level",
-  children: [
-      { label: "First Level" },
-      { label: "First Level", children: [{ label: "Second Level" }] },
-  ],
-})
+    label: 'Top Level',
+    children: [
+        { label: 'First Level' },
+        { label: 'First Level', children: [{ label: 'Second Level' }] },
+    ],
+});
 </script>

--- a/test/fixture/src/App.vue
+++ b/test/fixture/src/App.vue
@@ -1,22 +1,41 @@
 <template>
-  <ComponentA msg="a" />
-  <component-b msg="b" />
-  <ComponentC msg="c" />
-  <recursive :data="tree" />
-  <Book />
-  <!-- If you allow Folder Names uncomment these Components -->
-  <Avatar />
-  <Uibutton />
+  <div class="block">
+    <h1>Basic (4)</h1>
+    <ComponentA msg="a" />
+    <component-b msg="b" />
+    <ComponentC msg="c" />
+    <h3>Recursive Components</h3>
+    <recursive :data="tree" />
+  </div>
+
+  <div class="block">
+    <h1>Namespaced (4)</h1>
+    <!-- Index -->
+    <Book />
+    <UiButton />
+    <UiNestedCheckbox />
+    <!-- Global -->
+    <Avatar />
+  </div>
 </template>
 
 <script setup lang='ts'>
-import { ref } from 'vue';
+import { ref } from 'vue'
 
 export const tree = ref({
-    label: 'Top Level',
-    children: [
-        { label: 'First Level' },
-        { label: 'First Level', children: [{ label: 'Second Level' }] },
-    ],
-});
+  label: 'Top Level',
+  children: [
+    { label: 'First Level' },
+    { label: 'First Level', children: [{ label: 'Second Level' }] },
+  ],
+})
 </script>
+
+<style scoped>
+.block {
+  padding: 0px 20px 10px 20px;
+  margin: 20px 20px;
+  border: 1px solid #888;
+  border-radius: 5px;
+}
+</style>

--- a/test/fixture/src/App.vue
+++ b/test/fixture/src/App.vue
@@ -3,11 +3,10 @@
     <component-b msg="b" />
     <ComponentC msg="c" />
     <recursive :data="tree" />
+    <Book />
     <!-- If you allow Folder Names uncomment these Components -->
-    <!-- 
-        <avatar />
-        <ui-Button /> 
-    -->
+    <Avatar />
+    <Uibutton />
 </template>
 
 <script setup lang='ts'>

--- a/test/fixture/src/components/Recursive.vue
+++ b/test/fixture/src/components/Recursive.vue
@@ -2,7 +2,7 @@
   <div>
     <div>{{ data.label }}</div>
     <div class="child">
-      <recursive v-for="item in data.children" :data="item" />
+      <recursive v-for="(item, idx) in data.children" :key="idx" :data="item" />
     </div>
   </div>
 </template>

--- a/test/fixture/src/components/book/index.vue
+++ b/test/fixture/src/components/book/index.vue
@@ -1,9 +1,9 @@
 <template>
-  <h1>This is an Index Component named after its parent directory</h1>
+  <h3>Index Component: <code>book/index.vue</code></h3>
 </template>
 
 <script>
 export default {
-  name: "book",
+  name: 'Book',
 }
 </script>

--- a/test/fixture/src/components/book/index.vue
+++ b/test/fixture/src/components/book/index.vue
@@ -1,0 +1,9 @@
+<template>
+    <h1>This is an Index Component named after its parent directory</h1>
+</template>
+
+<script>
+export default {
+    name: "book",
+};
+</script>

--- a/test/fixture/src/components/book/index.vue
+++ b/test/fixture/src/components/book/index.vue
@@ -1,9 +1,9 @@
 <template>
-    <h1>This is an Index Component named after its parent directory</h1>
+  <h1>This is an Index Component named after its parent directory</h1>
 </template>
 
 <script>
 export default {
-    name: "book",
-};
+  name: "book",
+}
 </script>

--- a/test/fixture/src/components/global/avatar.vue
+++ b/test/fixture/src/components/global/avatar.vue
@@ -1,9 +1,9 @@
 <template>
-    <h1>This is a namespaced Component</h1>
+  <h1>This is a namespaced Component</h1>
 </template>
 
 <script>
 export default {
-    name: "avatar",
-};
+  name: "avatar",
+}
 </script>

--- a/test/fixture/src/components/global/avatar.vue
+++ b/test/fixture/src/components/global/avatar.vue
@@ -1,9 +1,9 @@
 <template>
-  <h1>This is a namespaced Component</h1>
+  <h3>Global Namespaced Component: <code>global/avatar.vue</code></h3>
 </template>
 
 <script>
 export default {
-  name: "avatar",
+  name: 'Avatar',
 }
 </script>

--- a/test/fixture/src/components/global/avatar.vue
+++ b/test/fixture/src/components/global/avatar.vue
@@ -1,0 +1,9 @@
+<template>
+    <h1>This is a namespaced Component</h1>
+</template>
+
+<script>
+export default {
+    name: "avatar",
+};
+</script>

--- a/test/fixture/src/components/ui/button.vue
+++ b/test/fixture/src/components/ui/button.vue
@@ -1,0 +1,9 @@
+<template>
+    <h1>This is a folder named Component</h1>
+</template>
+
+<script>
+export default {
+    name: "ui-button",
+};
+</script>

--- a/test/fixture/src/components/ui/button.vue
+++ b/test/fixture/src/components/ui/button.vue
@@ -1,9 +1,9 @@
 <template>
-  <h1>This is a folder named Component</h1>
+  <h3>Namespaced Component: <code>iu/button.vue</code></h3>
 </template>
 
 <script>
 export default {
-  name: "ui-button",
+  name: 'UiButton',
 }
 </script>

--- a/test/fixture/src/components/ui/button.vue
+++ b/test/fixture/src/components/ui/button.vue
@@ -1,9 +1,9 @@
 <template>
-    <h1>This is a folder named Component</h1>
+  <h1>This is a folder named Component</h1>
 </template>
 
 <script>
 export default {
-    name: "ui-button",
-};
+  name: "ui-button",
+}
 </script>

--- a/test/fixture/src/components/ui/nested/checkbox.vue
+++ b/test/fixture/src/components/ui/nested/checkbox.vue
@@ -1,0 +1,3 @@
+<template>
+  <h3>Nested Namespaced Component: <code>iu/nested/checkbox.vue</code></h3>
+</template>

--- a/test/fixture/src/index.css
+++ b/test/fixture/src/index.css
@@ -2,7 +2,6 @@
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
+  margin-top: 30px;
 }

--- a/test/fixture/vite.config.ts
+++ b/test/fixture/vite.config.ts
@@ -13,6 +13,9 @@ const config: UserConfig = {
   plugins: [
     ViteComponents({
       alias,
+
+      directoryAsNamespace: true,
+      globalNamespaces: ['global'],
     }),
   ],
 }


### PR DESCRIPTION
Hello there,
so ive created a smaller Pull Request that basically implements some Features that i had in my own `vite-autoloader`.
Due to it not beeing in Typescript ive converted all Features that were missing now over to this Plugin!

Features:
1.  Allow Folder Names ( boolean )

    This is just a simple Idea, if you for example got the following Folder Structure:

    ```
    src/components
    	book.vue
    	ui
    		button.vue
    	layout
    		content.vue
    	transition
    		fade.vue
    ```
    
    Components within these Subfolders would be generated like the following:
    
    `book.vue`, `uiButton.vue` , `layoutContent.vue`, `transitionFade.vue`
    
    This allows Users to have Componentnames based on their Foldestructure.
    
2. Namespacing ( array with strings )
   An Additional Feature to the first one: the user can allow specific Foldernames to be ignored within their Folderstructure:

   ```
    src/components
   	global
   		avatar.vue
   	partials
   		listItem.vue
   ```
   This would result in the components beeing named as: `avatar.vue`, `listItem.vue`

3.  Include_dirs and exclude_dirs ( array with strings )
    Pretty Simple, ive just changed `dirs` to `include_dirs` to make it more recognizable.
    I wanted to allow the Options also to `exclude_dirs`. This would mean that a User could ignore certain Folders within the `include_dirs` from getting autoloaded.

    ```
    src/components
    	test.vue (loaded)
    	ui
    		button.vue (loaded)
    	partials
    		listItem.vue (ignored)
    ```

    Unfortunately i didnt had the time to implement this in the current Repo, but i will try to add it later on! 

4.  Bugs:
    Currently there is only one Bug existent which is, if a component is loaded its name will `normalize` from `context.ts`. 

    ```
    src/components
    	ui
    		button.vue
    ```

    Ends up with: `Uibutton.vue` rather then `uiButton.vue`. I could change this behavior from `normalize` to `kebabCase`, but this would enforce a specific Loadingstyle. It would be great if a component could be loaded no matter how it is written: `ui-button.vue`, `uiButton.vue`, `Uibutton.vue`, `UiButton.vue` etc
    But due to my Typescript beeing a littly rusty i couldnt find a quick Solution that didnt break everything! I also fixed one Issue that `index-named` components were not loaded properly if they got their parent directory name.

    Last but not least: I dont like the current `allowFolderNames` Option, so if someone finds a better name for it, feel free to change it! and please verify if this works on `MACOS` and `Linux`, because i am currently limited to `Windows 10 64Bit`.

    

    

    Greetings,

    Subwaytime