### PR TITLE
feat: add svg support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "npm run build -- --watch",
     "fixture:dev": "npm -C test/fixture run dev",
     "fixture:build": "npm -C test/fixture run build",
-    "build": "tsup src/index.ts --dts --format cjs,esm",
+    "build": "tsup src/index.ts --dts --format cjs,esm --external @vue/compiler-sfc",
     "prepare": "npm run build",
     "release": "standard-version && npm publish && git push"
   },
@@ -34,6 +34,7 @@
     "@types/debug": "^4.1.5",
     "@types/minimatch": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
+    "@vue/compiler-sfc": "^3.0.3",
     "eslint": "^7.11.0",
     "rollup": "^2.32.1",
     "standard-version": "^9.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createServerPlugin } from './plugins/server'
 import { Options } from './types'
 import { VueScriptTransformer } from './transforms/vueScript'
 import { VueTemplateTransformer } from './transforms/vueTemplate'
+import { SVGTransformer } from './transforms/svg'
 import { Context } from './context'
 
 const defaultOptions: Options = {
@@ -32,6 +33,7 @@ function VitePluginComponents(options: Partial<Options> = {}): Plugin {
     transforms: [
       VueScriptTransformer(ctx),
       VueTemplateTransformer(ctx),
+      SVGTransformer(ctx),
     ],
   }
 }

--- a/src/transforms/svg.ts
+++ b/src/transforms/svg.ts
@@ -17,12 +17,11 @@ export function SVGTransformer(ctx: Context): Transform {
     transform({ path }) {
       debug(path)
       const svg = readFileSync(path, 'utf8')
-      let { code } = compileTemplate({
+      const { code } = compileTemplate({
         source: svg,
         transformAssetUrls: false,
       })
-      code = code.replace('export function render', 'export default function render')
-      return `${code}`
+      return code.replace('export function render', 'export default function render')
     },
   }
 }

--- a/src/transforms/svg.ts
+++ b/src/transforms/svg.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'fs'
+import Debug from 'debug'
+import type { Transform } from 'vite'
+import { compileTemplate } from '@vue/compiler-sfc'
+import { Context } from '../context'
+
+const debug = Debug('vite-plugin-components:transform:svg')
+
+/**
+ * @param ctx
+ */
+export function SVGTransformer(ctx: Context): Transform {
+  return {
+    test({ path, query }) {
+      return path.endsWith('.svg') && query.import != null
+    },
+    transform({ path }) {
+      debug(path)
+      const svg = readFileSync(path, 'utf8')
+      let { code } = compileTemplate({
+        source: svg,
+        transformAssetUrls: false,
+      })
+      code = code.replace('export function render', 'export default function render')
+      return `${code}`
+    },
+  }
+}

--- a/test/fixture/src/App.vue
+++ b/test/fixture/src/App.vue
@@ -16,6 +16,7 @@
     <UiNestedCheckbox />
     <!-- Global -->
     <Avatar />
+    <SvgComponent />
   </div>
 </template>
 

--- a/test/fixture/src/components/svg-component.svg
+++ b/test/fixture/src/components/svg-component.svg
@@ -1,0 +1,26 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  aria-hidden="true"
+  focusable="false"
+  role="img"
+  class="iconify iconify--logos"
+  width="1.16em"
+  height="1em"
+  preserveAspectRatio="xMidYMid meet"
+  viewBox="0 0 256 221"
+  style="transform: rotate(360deg)"
+>
+  <path
+    d="M204.8 0H256L128 220.8L0 0h97.92L128 51.2L157.44 0h47.36z"
+    fill="#41B883"
+  ></path>
+  <path
+    d="M0 0l128 220.8L256 0h-51.2L128 132.48L50.56 0H0z"
+    fill="#41B883"
+  ></path>
+  <path
+    d="M50.56 0L128 133.12L204.8 0h-47.36L128 51.2L97.92 0H50.56z"
+    fill="#35495E"
+  ></path>
+</svg>

--- a/test/fixture/vite.config.ts
+++ b/test/fixture/vite.config.ts
@@ -13,7 +13,7 @@ const config: UserConfig = {
   plugins: [
     ViteComponents({
       alias,
-
+      extensions: ['vue', 'svg'],
       directoryAsNamespace: true,
       globalNamespaces: ['global'],
     }),


### PR DESCRIPTION
Fix: #9 

I left over things I dont understand:
- I ignored type error on line 20.
- No __hmrId like vite-plugin-svg

I didn't use vite-plugin-svg because I dont like renaming components while importing -> `import { VueComponent as MyIcon }`

I didn't implement SVGO optimization. I prefer using https://jakearchibald.github.io/svgomg/ or do myself manually. Can be added later as optionally.

Also I didn't push lock file.