### PR TITLE
feat: add svg component support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
     "vue": "^3.0.3"
   },
   "devDependencies": {
+    "vite-plugin-svg": "^0.7.0",
     "@vue/compiler-sfc": "^3.0.3",
     "cross-env": "^7.0.2",
     "typescript": "^4.1.2",

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -5,6 +5,9 @@
     <component-b msg="b" />
     <ComponentC msg="c" />
     <ComponentD />
+    <h1>SVG Component (2)</h1>
+    <SvgComponent />
+    <img src="./components/svg-component.svg" alt="">
     <h3>Recursive Components</h3>
     <recursive :data="tree" />
   </div>

--- a/example/src/components/svg-component.svg
+++ b/example/src/components/svg-component.svg
@@ -1,0 +1,26 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  aria-hidden="true"
+  focusable="false"
+  role="img"
+  class="iconify iconify--logos"
+  width="1.16em"
+  height="1em"
+  preserveAspectRatio="xMidYMid meet"
+  viewBox="0 0 256 221"
+  style="transform: rotate(360deg)"
+>
+  <path
+    d="M204.8 0H256L128 220.8L0 0h97.92L128 51.2L157.44 0h47.36z"
+    fill="#41B883"
+  ></path>
+  <path
+    d="M0 0l128 220.8L256 0h-51.2L128 132.48L50.56 0H0z"
+    fill="#41B883"
+  ></path>
+  <path
+    d="M50.56 0L128 133.12L204.8 0h-47.36L128 51.2L97.92 0H50.56z"
+    fill="#35495E"
+  ></path>
+</svg>

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { UserConfig } from 'vite'
 import ViteComponents from 'vite-plugin-components'
 import Markdown from 'vite-plugin-md'
+import svg from 'vite-plugin-svg'
 
 const alias = {
   '/~/': path.resolve(__dirname, 'src'),
@@ -13,12 +14,14 @@ const config: UserConfig = {
   },
   plugins: [
     Markdown(),
+    svg(),
     ViteComponents({
-      extensions: ['vue', 'md'],
+      extensions: ['vue', 'md', 'svg'],
       alias,
       directoryAsNamespace: true,
       globalNamespaces: ['global'],
       customLoaderMatcher: ({ path }) => path.endsWith('.md'),
+      customImportMapper: (name, path) => path.endsWith('.svg') ? `import { VueComponent as ${name} } from "/${path}"` : false,
     }),
   ],
 }

--- a/src/generator/resolver.ts
+++ b/src/generator/resolver.ts
@@ -33,7 +33,7 @@ export async function generateResolver(ctx: Context, reqPath: string) {
   debug('using', names, 'imported', components.map(i => i.name))
 
   return `
-    ${components.map(({ name, path }) => `import ${name} from "/${path}"`).join('\n')}
+    ${components.map(({ name, path }) => ctx.options.customImportMapper(name, path) || `import ${name} from "/${path}"`).join('\n')}
 
     export default (components) => { 
       return Object.assign({}, { ${components.map(i => i.name).join(', ')} }, components) 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const defaultOptions: Options = {
   root: process.cwd(),
 
   customLoaderMatcher: () => false,
+  customImportMapper: () => false,
 }
 
 function VitePluginComponents(options: Partial<Options> = {}): Plugin {

--- a/src/transforms/customComponent.ts
+++ b/src/transforms/customComponent.ts
@@ -39,7 +39,7 @@ export function CustomComponentTransformer(ctx: Context): Transform {
             continue
 
           const var_name = `__vite_component_${id}`
-          lines.push(`import ${var_name} from "/${component.path}"`)
+          lines.push(ctx.options.customImportMapper(var_name, component.path) || `import ${var_name} from "/${component.path}"`)
           id += 1
 
           injected.push(`"${name}": ${var_name}`)

--- a/src/transforms/vueScriptSetup.ts
+++ b/src/transforms/vueScriptSetup.ts
@@ -23,7 +23,7 @@ export function VueScriptSetupTransformer(ctx: Context): Transform {
           const component = ctx.findComponent(normalize(match), [sfcPath])
           if (component) {
             const var_name = `__vite_component_${id}`
-            head.push(`import ${var_name} from "/${component.path}"`)
+            head.push(ctx.options.customImportMapper(var_name, component.path) || `import ${var_name} from "/${component.path}"`)
             id += 1
             return var_name
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,13 @@ export interface Options {
    * @default ()=>false
    */
   customLoaderMatcher: Transform['test']
+
+  /**
+   * Custom import statement mapper for custom loaders.
+   *
+   * @default ()=>false
+   */
+  customImportMapper: (name: string, path: string) => string | false
 }
 
 export interface ComponentsInfo {


### PR DESCRIPTION
Fix #9 

Another try. As far as I see it is works with `vite build` and `<img>` tag.

Currently there are some repetitive code across files. Maybe some of them aren't even necessary. But I'm not sure some thems actual effect. I try do it with `customLoaderMatcher` but as far as I see it is unnecessary and doesn't met our specific use case (custom import statements). 

Would like to hear your thoughs 😊