### PR TITLE
feat(resolver): add headlessUi resolver

### DIFF
--- a/src/resolvers/headlessUi.ts
+++ b/src/resolvers/headlessUi.ts
@@ -1,0 +1,48 @@
+import { ComponentResolver } from '../types'
+
+const components = [
+  'Dialog',
+  'DialogDescription',
+  'DialogOverlay',
+  'DialogTitle',
+  'Disclosure',
+  'DisclosureButton',
+  'DisclosurePanel',
+  'FocusTrap',
+  'Listbox',
+  'ListboxButton',
+  'ListboxLabel',
+  'ListboxOption',
+  'ListboxOptions',
+  'Menu',
+  'MenuButton',
+  'MenuItem',
+  'MenuItems',
+  'Popover',
+  'PopoverButton',
+  'PopoverGroup',
+  'PopoverOverlay',
+  'PopoverPanel',
+  'Portal',
+  'PortalGroup',
+  'RadioGroup',
+  'RadioGroupDescription',
+  'RadioGroupLabel',
+  'RadioGroupOption',
+  'Switch',
+  'SwitchDescription',
+  'SwitchGroup',
+  'SwitchLabel',
+  'TransitionChild',
+  'TransitionRoot',
+]
+
+/**
+ * Resolver for headlessui
+ *
+ * @link https://github.com/tailwindlabs/headlessui
+ */
+export const HeadlessUiResolver = (): ComponentResolver => (name: string) => {
+  if (components.includes(name))
+    return { importName: name, path: '@headlessui/vue' }
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,4 +1,5 @@
 export * from './antdv'
 export * from './element-plus'
+export * from './headlessUi'
 export * from './vant'
 export * from './vuetify'


### PR DESCRIPTION
Hi people!

I created a resolver for headlessUi
https://github.com/tailwindlabs/headlessui

The problem with headlessUi is, that its components are not prefixed and therefore a simple regex or startsWith cannot be used to identify them. As you can see the solution for this was having a string array with all component names and checking if the resolved component is included. Having a hardcoded array of names is not an optimal solution.

The headlessUi package exports all the components. A dynamic solution could look something like this:

`import * as components from '@headlessui/vue'`
`const components = Object.keys(components)`

The downside to this is, that you have to import the whole package.

I do not know which solution is better, so feedback is welcome.

PS: This is my first contribution to an open source project. Please let me know if I did anything wrong. 


Greetings
Yannic

