### PR TITLE
fix: watcher not works under components dir in windows

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -38,9 +38,8 @@ export class Context {
   setServer(server: ViteDevServer) {
     this._server = server
 
-    const { globs, dirs } = this.options
+    const { globs } = this.options
 
-    server.watcher.add(dirs)
     server.watcher
       .on('unlink', (path) => {
         if (!matchGlobs(path, globs))

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,15 +12,6 @@ function VitePluginComponents(options: Options = {}): Plugin {
   return {
     name: 'vite-plugin-components',
     enforce: 'post',
-    config() {
-      return {
-        server: {
-          watch: {
-            disableGlobbing: false,
-          },
-        },
-      }
-    },
     configResolved(config) {
       if (config.plugins.find(i => i.name === 'vite-plugin-vue2'))
         options.transformer = options.transformer || 'vue2'


### PR DESCRIPTION
In windows, if you add components dir to watchlist, the watcher will not works under components dir.

Also, Vite is defaulted to watching everything under root dir, so I think we don't need to add components dir manually.

close #86 
close https://github.com/antfu/vitesse/issues/149