### PR TITLE
feat(antdv): add antdv icons resolve options.

### DIFF
--- a/src/resolvers/antdv.ts
+++ b/src/resolvers/antdv.ts
@@ -175,6 +175,15 @@ export interface AntDesignVueResolverOptions {
    * @default false
    */
   importLess?: boolean
+
+  /**
+   * should resolve `ant-design-vue' icons 
+   * 
+   * required package `@ant-design/icons-vue`
+   * 
+   * @default undefined
+   */
+  resolveIcons?: boolean;
 }
 
 const getStyleDir = (compName: string): string => {
@@ -213,6 +222,13 @@ const getSideEffects: (
 export const AntDesignVueResolver
   = (options: AntDesignVueResolverOptions = {}): ComponentResolver =>
     (name: string) => {
+      if(options.resolveIcons && name.match(/(Outlined|Filled|TwoTone)$/)){
+        return {
+          importName: name,
+          path: "@ant-design/icons-vue"
+        }
+      }
+
       if (name.match(/^A[A-Z]/)) {
         const importName = name.slice(1)
         return {

--- a/src/resolvers/antdv.ts
+++ b/src/resolvers/antdv.ts
@@ -181,7 +181,7 @@ export interface AntDesignVueResolverOptions {
    * 
    * required package `@ant-design/icons-vue`
    * 
-   * @default undefined
+   * @default false
    */
   resolveIcons?: boolean;
 }

--- a/src/resolvers/antdv.ts
+++ b/src/resolvers/antdv.ts
@@ -175,15 +175,14 @@ export interface AntDesignVueResolverOptions {
    * @default false
    */
   importLess?: boolean
-
   /**
-   * should resolve `ant-design-vue' icons 
-   * 
-   * required package `@ant-design/icons-vue`
-   * 
+   * resolve `ant-design-vue' icons
+   *
+   * requires package `@ant-design/icons-vue`
+   *
    * @default false
    */
-  resolveIcons?: boolean;
+  resolveIcons?: boolean
 }
 
 const getStyleDir = (compName: string): string => {
@@ -222,10 +221,10 @@ const getSideEffects: (
 export const AntDesignVueResolver
   = (options: AntDesignVueResolverOptions = {}): ComponentResolver =>
     (name: string) => {
-      if(options.resolveIcons && name.match(/(Outlined|Filled|TwoTone)$/)){
+      if (options.resolveIcons && name.match(/(Outlined|Filled|TwoTone)$/)) {
         return {
           importName: name,
-          path: "@ant-design/icons-vue"
+          path: '@ant-design/icons-vue',
         }
       }
 


### PR DESCRIPTION
AntdDesignVue`s icons is a alone package, so we need to import icons from @ant-design/icons-vue.

[click here for detail](https://2x.antdv.com/components/icon)